### PR TITLE
Bugfix 31867 fix upload file with spaces in name

### DIFF
--- a/Modules/IndividualAssessment/classes/FileStorage/class.ilIndividualAssessmentFileStorage.php
+++ b/Modules/IndividualAssessment/classes/FileStorage/class.ilIndividualAssessmentFileStorage.php
@@ -62,7 +62,7 @@ class ilIndividualAssessmentFileStorage extends ilFileSystemStorage implements I
     /**
      * creates the folder structure
      *
-     * @return boolen
+     * @return boolean
      */
     public function create()
     {
@@ -139,8 +139,7 @@ class ilIndividualAssessmentFileStorage extends ilFileSystemStorage implements I
      */
     public function deleteCurrentFile()
     {
-        $files = $this->readDir();
-        $this->deleteFile($this->getAbsolutePath() . "/" . $files[0]);
+        $this->deleteFile($this->getFilePath());
     }
 
     /**
@@ -150,8 +149,18 @@ class ilIndividualAssessmentFileStorage extends ilFileSystemStorage implements I
      */
     public function getFilePath()
     {
+        return $this->getAbsolutePath() . "/" . $this->getFileName();
+    }
+
+    /**
+     * Get the name of file
+     *
+     * @return string
+     */
+    public function getFileName()
+    {
         $files = $this->readDir();
-        return $this->getAbsolutePath() . "/" . $files[0];
+        return $files[0];
     }
 
     /**

--- a/Modules/IndividualAssessment/classes/FileStorage/class.ilIndividualAssessmentFileStorage.php
+++ b/Modules/IndividualAssessment/classes/FileStorage/class.ilIndividualAssessmentFileStorage.php
@@ -114,9 +114,10 @@ class ilIndividualAssessmentFileStorage extends ilFileSystemStorage implements I
     /**
      * Upload the file
      *
-     * @param string[]
+     * @param UploadResult $result
      *
      * @return bool
+     * @throws ilException
      */
     public function uploadFile(UploadResult $result)
     {
@@ -143,7 +144,7 @@ class ilIndividualAssessmentFileStorage extends ilFileSystemStorage implements I
     }
 
     /**
-     * Get the path of file
+     * Get the path of the file
      *
      * @return string
      */
@@ -153,7 +154,7 @@ class ilIndividualAssessmentFileStorage extends ilFileSystemStorage implements I
     }
 
     /**
-     * Get the name of file
+     * Get the name of the file
      *
      * @return string
      */

--- a/Modules/IndividualAssessment/classes/class.ilIndividualAssessmentMemberGUI.php
+++ b/Modules/IndividualAssessment/classes/class.ilIndividualAssessmentMemberGUI.php
@@ -554,7 +554,7 @@ class ilIndividualAssessmentMemberGUI extends AbstractCtrlAwareUploadHandler
         $storage->deleteCurrentFile();
         $storage->uploadFile($result);
 
-        return $result->getName();
+        return $storage->getFileName();
     }
 
     protected function deleteFile()

--- a/Modules/IndividualAssessment/interfaces/FileStorage/interface.IndividualAssessmentFileStorage.php
+++ b/Modules/IndividualAssessment/interfaces/FileStorage/interface.IndividualAssessmentFileStorage.php
@@ -7,6 +7,7 @@ interface IndividualAssessmentFileStorage
     public function isEmpty();
     public function deleteCurrentFile();
     public function getFilePath();
+    public function getFileName();
     public function uploadFile(UploadResult $file);
     public function create();
     /**


### PR DESCRIPTION
#bugfix
target: release_7
mantis issue: 31867 and 32905
https://mantis.ilias.de/view.php?id=31867
https://mantis.ilias.de/view.php?id=32905

During upload the file name is cleaned up, removing special characters and spaces. The wrong (unchanged) filename was being returned and therefore the wrong filename was being requested in subsequent calls.

Changes in class.ilIndividualAssessmentMemberGUI.php fix the issue.
Changes in class.ilIndividualAssessmentFileStorage.php are not all strictly necessary. The new function `getFileName` holds code that was repeated in the class before, and it makes the fix easy to read.
Before modifying the corresponding interface `interface.IndividualAssessmentFileStorage` I made sure it is not implemented anywhere else.